### PR TITLE
Feature/#43 add extension ui color

### DIFF
--- a/Oshidori.xcodeproj/project.pbxproj
+++ b/Oshidori.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		67C9E04C225EC20200516B3D /* TimelineMessageTableViewCellTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C9E04A225EC20200516B3D /* TimelineMessageTableViewCellTableViewCell.swift */; };
 		67C9E04D225EC20200516B3D /* TimelineMessageTableViewCellTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 67C9E04B225EC20200516B3D /* TimelineMessageTableViewCellTableViewCell.xib */; };
 		67C9E04F225EC22E00516B3D /* TimelineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C9E04E225EC22E00516B3D /* TimelineViewController.swift */; };
+		67C9E0512260131700516B3D /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C9E0502260131700516B3D /* UIColor.swift */; };
+		67C9E053226017B200516B3D /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C9E052226017B200516B3D /* TabBarController.swift */; };
 		71F8B5DA7E61B3C10BA63779 /* Pods_OshidoriUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7700FA585812734E8D2C9BA0 /* Pods_OshidoriUITests.framework */; };
 		C74256F218E242436241BFE4 /* Pods_OshidoriTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 269001C7C32D0828E6D11825 /* Pods_OshidoriTests.framework */; };
 /* End PBXBuildFile section */
@@ -90,6 +92,8 @@
 		67C9E04A225EC20200516B3D /* TimelineMessageTableViewCellTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineMessageTableViewCellTableViewCell.swift; sourceTree = "<group>"; };
 		67C9E04B225EC20200516B3D /* TimelineMessageTableViewCellTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TimelineMessageTableViewCellTableViewCell.xib; sourceTree = "<group>"; };
 		67C9E04E225EC22E00516B3D /* TimelineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineViewController.swift; sourceTree = "<group>"; };
+		67C9E0502260131700516B3D /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
+		67C9E052226017B200516B3D /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		7700FA585812734E8D2C9BA0 /* Pods_OshidoriUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OshidoriUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		94F39C30B74CB220E1073109 /* Pods-Oshidori.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Oshidori.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Oshidori/Pods-Oshidori.debug.xcconfig"; sourceTree = "<group>"; };
 		A484EA0957D17B99E82E6CB8 /* Pods-OshidoriTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OshidoriTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OshidoriTests/Pods-OshidoriTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -175,6 +179,7 @@
 			isa = PBXGroup;
 			children = (
 				6732F27F224DB2F500011710 /* AppDelegate.swift */,
+				67C9E052226017B200516B3D /* TabBarController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -196,6 +201,7 @@
 			children = (
 				6723DEB422509BA100B3DF69 /* UIViewController.swift */,
 				6736F1622254B45000E89952 /* UserDefault.swift */,
+				67C9E0502260131700516B3D /* UIColor.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -518,9 +524,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				6723DEB522509BA100B3DF69 /* UIViewController.swift in Sources */,
+				67C9E053226017B200516B3D /* TabBarController.swift in Sources */,
 				6723DEA8224F10B600B3DF69 /* LoginViewController.swift in Sources */,
 				6736F1632254B45000E89952 /* UserDefault.swift in Sources */,
 				6723DEBE2254396700B3DF69 /* Message.swift in Sources */,
+				67C9E0512260131700516B3D /* UIColor.swift in Sources */,
 				6723DEB82250AA7500B3DF69 /* RegisterViewController.swift in Sources */,
 				6732F280224DB2F500011710 /* AppDelegate.swift in Sources */,
 				6723DEAC224F51C800B3DF69 /* User.swift in Sources */,

--- a/Oshidori.xcodeproj/project.pbxproj
+++ b/Oshidori.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		67C9E04C225EC20200516B3D /* TimelineMessageTableViewCellTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C9E04A225EC20200516B3D /* TimelineMessageTableViewCellTableViewCell.swift */; };
 		67C9E04D225EC20200516B3D /* TimelineMessageTableViewCellTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 67C9E04B225EC20200516B3D /* TimelineMessageTableViewCellTableViewCell.xib */; };
 		67C9E04F225EC22E00516B3D /* TimelineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C9E04E225EC22E00516B3D /* TimelineViewController.swift */; };
-		67C9E0512260131700516B3D /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C9E0502260131700516B3D /* UIColor.swift */; };
+		67C9E0512260131700516B3D /* OshidoriColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C9E0502260131700516B3D /* OshidoriColor.swift */; };
 		67C9E053226017B200516B3D /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C9E052226017B200516B3D /* TabBarController.swift */; };
 		71F8B5DA7E61B3C10BA63779 /* Pods_OshidoriUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7700FA585812734E8D2C9BA0 /* Pods_OshidoriUITests.framework */; };
 		C74256F218E242436241BFE4 /* Pods_OshidoriTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 269001C7C32D0828E6D11825 /* Pods_OshidoriTests.framework */; };
@@ -92,7 +92,7 @@
 		67C9E04A225EC20200516B3D /* TimelineMessageTableViewCellTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineMessageTableViewCellTableViewCell.swift; sourceTree = "<group>"; };
 		67C9E04B225EC20200516B3D /* TimelineMessageTableViewCellTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TimelineMessageTableViewCellTableViewCell.xib; sourceTree = "<group>"; };
 		67C9E04E225EC22E00516B3D /* TimelineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineViewController.swift; sourceTree = "<group>"; };
-		67C9E0502260131700516B3D /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
+		67C9E0502260131700516B3D /* OshidoriColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OshidoriColor.swift; sourceTree = "<group>"; };
 		67C9E052226017B200516B3D /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		7700FA585812734E8D2C9BA0 /* Pods_OshidoriUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OshidoriUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		94F39C30B74CB220E1073109 /* Pods-Oshidori.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Oshidori.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Oshidori/Pods-Oshidori.debug.xcconfig"; sourceTree = "<group>"; };
@@ -201,7 +201,6 @@
 			children = (
 				6723DEB422509BA100B3DF69 /* UIViewController.swift */,
 				6736F1622254B45000E89952 /* UserDefault.swift */,
-				67C9E0502260131700516B3D /* UIColor.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -233,6 +232,7 @@
 			children = (
 				6723DEAF224F740600B3DF69 /* Entities */,
 				6707D3DB225AE7CC007529FA /* Cell */,
+				6739F08A22607B7700584603 /* Inheritance */,
 				6723DEB622509BAF00B3DF69 /* Extension */,
 				6723DEB2224F74CB00B3DF69 /* Controllers */,
 				6723DEB1224F74B100B3DF69 /* ViewControllers */,
@@ -261,6 +261,14 @@
 				6732F2A4224DB2F600011710 /* Info.plist */,
 			);
 			path = OshidoriUITests;
+			sourceTree = "<group>";
+		};
+		6739F08A22607B7700584603 /* Inheritance */ = {
+			isa = PBXGroup;
+			children = (
+				67C9E0502260131700516B3D /* OshidoriColor.swift */,
+			);
+			path = Inheritance;
 			sourceTree = "<group>";
 		};
 		E07BC4EC061E887F5CAE56AD /* Frameworks */ = {
@@ -528,7 +536,7 @@
 				6723DEA8224F10B600B3DF69 /* LoginViewController.swift in Sources */,
 				6736F1632254B45000E89952 /* UserDefault.swift in Sources */,
 				6723DEBE2254396700B3DF69 /* Message.swift in Sources */,
-				67C9E0512260131700516B3D /* UIColor.swift in Sources */,
+				67C9E0512260131700516B3D /* OshidoriColor.swift in Sources */,
 				6723DEB82250AA7500B3DF69 /* RegisterViewController.swift in Sources */,
 				6732F280224DB2F500011710 /* AppDelegate.swift in Sources */,
 				6723DEAC224F51C800B3DF69 /* User.swift in Sources */,

--- a/Oshidori/Controllers/AppDelegate.swift
+++ b/Oshidori/Controllers/AppDelegate.swift
@@ -20,13 +20,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         FirebaseApp.configure()
         
+        // 全てのNavigation Barの色を変更する
         // Navigation Bar の背景色の変更
         UINavigationBar.appearance().barTintColor = UIColor.lightColor()
         // Navigation Bar の文字色の変更
         UINavigationBar.appearance().tintColor = UIColor.darkColor()
         // Navigation Bar のタイトルの文字色の変更
         UINavigationBar.appearance().titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.darkColor()]
-
         return true
     }
 

--- a/Oshidori/Controllers/AppDelegate.swift
+++ b/Oshidori/Controllers/AppDelegate.swift
@@ -22,11 +22,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // 全てのNavigation Barの色を変更する
         // Navigation Bar の背景色の変更
-        UINavigationBar.appearance().barTintColor = UIColor.lightColor()
+        UINavigationBar.appearance().barTintColor = OshidoriColor.light
         // Navigation Bar の文字色の変更
-        UINavigationBar.appearance().tintColor = UIColor.darkColor()
+        UINavigationBar.appearance().tintColor = OshidoriColor.dark
         // Navigation Bar のタイトルの文字色の変更
-        UINavigationBar.appearance().titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.darkColor()]
+        UINavigationBar.appearance().titleTextAttributes = [NSAttributedString.Key.foregroundColor: OshidoriColor.dark]
         return true
     }
 

--- a/Oshidori/Controllers/AppDelegate.swift
+++ b/Oshidori/Controllers/AppDelegate.swift
@@ -19,6 +19,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         FirebaseApp.configure()
+        
+        // Navigation Bar の背景色の変更
+        UINavigationBar.appearance().barTintColor = UIColor.lightColor()
+        // Navigation Bar の文字色の変更
+        UINavigationBar.appearance().tintColor = UIColor.darkColor()
+        // Navigation Bar のタイトルの文字色の変更
+        UINavigationBar.appearance().titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.darkColor()]
+
         return true
     }
 

--- a/Oshidori/Controllers/TabBarController.swift
+++ b/Oshidori/Controllers/TabBarController.swift
@@ -1,0 +1,34 @@
+//
+//  TabBarController.swift
+//  Oshidori
+//
+//  Created by 山本竜也 on 2019/4/12.
+//  Copyright © 2019 山本竜也. All rights reserved.
+//
+
+import UIKit
+
+class TabBarController: UITabBarController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // カスタマイズ
+        // アイコンの色
+        UITabBar.appearance().tintColor = UIColor.darkColor()
+        // 背景色
+        UITabBar.appearance().barTintColor = UIColor.lightColor()
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Oshidori/Controllers/TabBarController.swift
+++ b/Oshidori/Controllers/TabBarController.swift
@@ -13,11 +13,10 @@ class TabBarController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        // カスタマイズ
         // アイコンの色
-        UITabBar.appearance().tintColor = UIColor.darkColor()
+        UITabBar.appearance().tintColor = OshidoriColor.dark
         // 背景色
-        UITabBar.appearance().barTintColor = UIColor.lightColor()
+        UITabBar.appearance().barTintColor = OshidoriColor.light
     }
     
 

--- a/Oshidori/Extension/UIColor.swift
+++ b/Oshidori/Extension/UIColor.swift
@@ -1,0 +1,49 @@
+//
+//  UIColor.swift
+//  Oshidori
+//
+//  Created by 山本竜也 on 2019/4/12.
+//  Copyright © 2019 山本竜也. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension UIColor {
+    
+    // class修飾子は、overrideを利用できるため、primaryColorをこの画面だけ変更したいという意図を汲み取れるようになる。
+    // 濃い緑を返す
+    class func primaryColor()->UIColor{
+        return UIColor.rgbColor(rgbValue: 0x73C6B6)
+    }
+    
+    // 薄いオレンジを返す
+    class func secondaryColor()->UIColor{
+        return UIColor.rgbColor(rgbValue: 0xFFD6BA)
+    }
+    
+    // 白っぽい灰色を返す
+    class func backgroundColor()->UIColor{
+        return UIColor.rgbColor(rgbValue: 0xFAF9F9)
+    }
+    
+    // 薄い緑を返す
+    class func lightColor()->UIColor{
+        return UIColor.rgbColor(rgbValue: 0xE8F7F4)
+    }
+    
+    // ほぼ黒に近い青を返す
+    class func darkColor()->UIColor{
+        return UIColor.rgbColor(rgbValue: 0x555B6E)
+    }
+    
+    // #FFFFFFのように色を指定できるようになる
+    class func rgbColor(rgbValue: UInt) -> UIColor{
+        return UIColor(
+            red:   CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
+            green: CGFloat((rgbValue & 0x00FF00) >>  8) / 255.0,
+            blue:  CGFloat( rgbValue & 0x0000FF)        / 255.0,
+            alpha: CGFloat(1.0)
+        )
+    }
+}

--- a/Oshidori/Inheritance/OshidoriColor.swift
+++ b/Oshidori/Inheritance/OshidoriColor.swift
@@ -9,36 +9,36 @@
 import Foundation
 import UIKit
 
-extension UIColor {
+class OshidoriColor: UIColor {
     
     // class修飾子は、overrideを利用できるため、primaryColorをこの画面だけ変更したいという意図を汲み取れるようになる。
     // 濃い緑を返す
-    class func primaryColor()->UIColor{
-        return UIColor.rgbColor(rgbValue: 0x73C6B6)
+    class var primary: UIColor {
+        return rgbColor(rgbValue: 0x73C6B6)
     }
     
     // 薄いオレンジを返す
-    class func secondaryColor()->UIColor{
-        return UIColor.rgbColor(rgbValue: 0xFFD6BA)
+    class var secondary: UIColor {
+        return rgbColor(rgbValue: 0xFFD6BA)
     }
     
     // 白っぽい灰色を返す
-    class func backgroundColor()->UIColor{
-        return UIColor.rgbColor(rgbValue: 0xFAF9F9)
+    class var background: UIColor {
+        return rgbColor(rgbValue: 0xFAF9F9)
     }
     
     // 薄い緑を返す
-    class func lightColor()->UIColor{
-        return UIColor.rgbColor(rgbValue: 0xE8F7F4)
+    class var light: UIColor {
+        return rgbColor(rgbValue: 0xE8F7F4)
     }
     
     // ほぼ黒に近い青を返す
-    class func darkColor()->UIColor{
-        return UIColor.rgbColor(rgbValue: 0x555B6E)
+    class var dark: UIColor {
+        return rgbColor(rgbValue: 0x555B6E)
     }
     
     // #FFFFFFのように色を指定できるようになる
-    class func rgbColor(rgbValue: UInt) -> UIColor{
+    private class func rgbColor(rgbValue: UInt) -> UIColor{
         return UIColor(
             red:   CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
             green: CGFloat((rgbValue & 0x00FF00) >>  8) / 255.0,

--- a/Oshidori/Storyboards/Tabbar.storyboard
+++ b/Oshidori/Storyboards/Tabbar.storyboard
@@ -12,8 +12,7 @@
         <!--Tab Bar Controller-->
         <scene sceneID="HYI-Fh-FUp">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="2ri-3J-yEf" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <tabBarController storyboardIdentifier="TabbarStoryboard" id="iiR-in-8hj" sceneMemberID="viewController">
+                <tabBarController storyboardIdentifier="TabbarStoryboard" id="iiR-in-8hj" customClass="TabBarController" customModule="Oshidori" customModuleProvider="target" sceneMemberID="viewController">
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="XFH-FO-RCH">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="49"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -24,6 +23,7 @@
                         <segue destination="0lT-hk-dY0" kind="relationship" relationship="viewControllers" id="q5F-z3-u2g"/>
                     </connections>
                 </tabBarController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="2ri-3J-yEf" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-646" y="-151"/>
         </scene>

--- a/Oshidori/Storyboards/Timeline.storyboard
+++ b/Oshidori/Storyboards/Timeline.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="04n-Po-db9">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="HYY-uv-QZv">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -18,12 +18,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bIo-Ik-RoD">
-                                <rect key="frame" x="0.0" y="20" width="375" height="44"/>
-                                <items>
-                                    <navigationItem title="タイムライン" id="MY5-g3-s8X"/>
-                                </items>
-                            </navigationBar>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="oVa-Jq-7Xa">
                                 <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -35,22 +29,38 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="bIo-Ik-RoD" firstAttribute="leading" secondItem="oVa-Jq-7Xa" secondAttribute="leading" id="2Db-hv-jk5"/>
-                            <constraint firstItem="bIo-Ik-RoD" firstAttribute="trailing" secondItem="oVa-Jq-7Xa" secondAttribute="trailing" id="8pI-wM-mQh"/>
                             <constraint firstItem="oVa-Jq-7Xa" firstAttribute="leading" secondItem="jzG-S4-mdj" secondAttribute="leading" id="8sz-Ud-1BE"/>
                             <constraint firstItem="oVa-Jq-7Xa" firstAttribute="bottom" secondItem="jzG-S4-mdj" secondAttribute="bottom" id="SFs-8e-V8c"/>
-                            <constraint firstItem="bIo-Ik-RoD" firstAttribute="top" secondItem="jzG-S4-mdj" secondAttribute="top" id="grE-NT-elb"/>
+                            <constraint firstItem="oVa-Jq-7Xa" firstAttribute="top" secondItem="jzG-S4-mdj" secondAttribute="top" id="hUT-Tq-Oqy"/>
                             <constraint firstItem="oVa-Jq-7Xa" firstAttribute="trailing" secondItem="jzG-S4-mdj" secondAttribute="trailing" id="mdk-cC-r6U"/>
-                            <constraint firstItem="oVa-Jq-7Xa" firstAttribute="top" secondItem="bIo-Ik-RoD" secondAttribute="bottom" id="pOq-ol-0Nh"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="jzG-S4-mdj"/>
                     </view>
-                    <tabBarItem key="tabBarItem" title="タイムライン" image="tabBarItem:pgT-aT-KZ5:image" selectedImage="tabBarItem:pgT-aT-KZ5:image" id="pgT-aT-KZ5"/>
+                    <navigationItem key="navigationItem" title="タイムライン" id="fQI-E4-1k4"/>
                     <connections>
                         <outlet property="timelineTableView" destination="oVa-Jq-7Xa" id="Xjs-2m-Qbj"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="rWp-mX-tRq" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="968.79999999999995" y="28.335832083958024"/>
+        </scene>
+        <!--タイムライン-->
+        <scene sceneID="RgN-5Z-4LY">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="HYY-uv-QZv" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="タイムライン" image="tabBarItem:pgT-aT-KZ5:image" selectedImage="tabBarItem:pgT-aT-KZ5:image" id="pgT-aT-KZ5"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Rbj-pZ-5v7">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="04n-Po-db9" kind="relationship" relationship="rootViewController" id="s8u-zn-CPD"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CWC-8p-ham" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="29.600000000000001" y="28.335832083958024"/>
         </scene>


### PR DESCRIPTION
fixes #43 
(#の後にcloseしたいissueの番号を記述してください)

## 概要
1. Extension UIColorを追加することで、PrimaryColorなどを一元管理できるようにしました
2. TabBarの背景色やアイコン色を変更しました
3. NavigationBarの文字色、背景色を変更しました

## 開発スコープ
UIColor.swift
Timeline.storyboard
AppDelegate.swift

## やっていないこと
色に関するところは全て変更しました
その他、バグに関すること。
→セルを超えて文字が表示されている
→なぜかTabbarのアイコンが表示されていない（特にエラーも出ていない。。。)

## デザイン
### 手紙の受信画面です！
<img width="410" alt="スクリーンショット 2019-04-12 10 27 16" src="https://user-images.githubusercontent.com/43805056/56005879-ac688600-5d0d-11e9-86b9-d9a0453418b9.png">

### 手紙の送信画面です！
<img width="410" alt="スクリーンショット 2019-04-12 10 27 26" src="https://user-images.githubusercontent.com/43805056/56005902-c86c2780-5d0d-11e9-82cd-9e1b5c92545b.png">

### タイムラインの画面です！
<img width="410" alt="スクリーンショット 2019-04-12 10 27 40" src="https://user-images.githubusercontent.com/43805056/56005912-cc984500-5d0d-11e9-9aa0-0a72343e008b.png">



